### PR TITLE
Fix timeout value bug. 1ms = 1_000_000ns

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -110,8 +110,9 @@ impl<'a> Data<'a> {
 		}
 		else {
 			unsafe {
+				// timeout is in milliseconds
 				hid_read_timeout(self.handle.as_mut_ptr(), data.as_mut_ptr(), data.len(),
-					timeout.as_secs() as c_int * 1_000 + timeout.subsec_nanos() as c_int * 1_000)
+					timeout.as_secs() as c_int * 1_000 + timeout.subsec_nanos() as c_int / 1_000_000)
 			}
 		};
 


### PR DESCRIPTION
Instead of dividing nanoseconds to get milliseconds, we were multiplying, which was causing integer overflow and the incorrect timeout value.