### PR TITLE
Make a device struct in charge of its own memory

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -13,8 +13,8 @@ pub struct Device {
 
 impl Device {
     #[doc(hidden)]
-    pub unsafe fn new<'b>(ptr: *const hid_device_info) -> Device {
-        Device { ptr: ptr }
+    pub unsafe fn new(ptr: *const hid_device_info) -> Device {
+        Device { ptr }
     }
 
     /// The path representation.
@@ -129,3 +129,6 @@ impl Drop for Device {
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 unsafe impl core::marker::Send for Device {}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+unsafe impl core::marker::Sync for Device {}

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,5 +1,4 @@
 use std::ffi::CStr;
-use std::marker::PhantomData;
 use std::path::Path;
 
 use error::{self, Error};
@@ -8,20 +7,14 @@ use libc::{size_t, wchar_t, wcstombs};
 use sys::*;
 
 /// The HID device.
-pub struct Device<'a> {
+pub struct Device {
     ptr: *const hid_device_info,
-
-    _marker: PhantomData<&'a ()>,
 }
 
-impl<'a> Device<'a> {
+impl Device {
     #[doc(hidden)]
-    pub unsafe fn new<'b>(ptr: *const hid_device_info) -> Device<'b> {
-        Device {
-            ptr: ptr,
-
-            _marker: PhantomData,
-        }
+    pub unsafe fn new<'b>(ptr: *const hid_device_info) -> Device {
+        Device { ptr: ptr }
     }
 
     /// The path representation.
@@ -119,3 +112,20 @@ unsafe fn to_string(value: *const wchar_t) -> Option<String> {
 
     Some(String::from_utf8_lossy(&buffer[0..length as usize]).into_owned())
 }
+
+impl Drop for Device {
+    fn drop(&mut self) {
+        unsafe {
+            if !self.ptr.is_null() {
+                libc::free((*self.ptr).path as *mut libc::c_void);
+                libc::free((*self.ptr).serial_number as *mut libc::c_void);
+                libc::free((*self.ptr).manufacturer_string as *mut libc::c_void);
+                libc::free((*self.ptr).product_string as *mut libc::c_void);
+                libc::free(self.ptr as *mut libc::c_void);
+            }
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+unsafe impl core::marker::Send for Device {}

--- a/src/devices.rs
+++ b/src/devices.rs
@@ -31,3 +31,13 @@ impl Iterator for Devices {
         }
     }
 }
+
+impl Drop for Devices {
+	fn drop(&mut self) {
+		if !self.cur.is_null() {
+			unsafe {
+				hid_free_enumeration(self.cur);
+			}
+		}
+	}
+}

--- a/src/devices.rs
+++ b/src/devices.rs
@@ -1,32 +1,22 @@
-use std::marker::PhantomData;
-
 use sys::*;
 use Device;
 
 /// An iterator over the available devices.
-pub struct Devices<'a> {
-    ptr: *mut hid_device_info,
+pub struct Devices {
     cur: *mut hid_device_info,
-
-    _marker: PhantomData<&'a ()>,
 }
 
-impl<'a> Devices<'a> {
+impl Devices {
     #[doc(hidden)]
     pub unsafe fn new(vendor: Option<u16>, product: Option<u16>) -> Self {
         let list = hid_enumerate(vendor.unwrap_or(0), product.unwrap_or(0));
 
-        Devices {
-            ptr: list,
-            cur: list,
-
-            _marker: PhantomData,
-        }
+        Devices { cur: list }
     }
 }
 
-impl<'a> Iterator for Devices<'a> {
-    type Item = Device<'a>;
+impl Iterator for Devices {
+    type Item = Device;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.cur.is_null() {
@@ -38,14 +28,6 @@ impl<'a> Iterator for Devices<'a> {
             self.cur = (*self.cur).next;
 
             Some(info)
-        }
-    }
-}
-
-impl<'a> Drop for Devices<'a> {
-    fn drop(&mut self) {
-        unsafe {
-            hid_free_enumeration(self.ptr);
         }
     }
 }


### PR DESCRIPTION
Currently, the lifetime of a `Device` is dependent on the `Devices` iterator that created it. I don't see a real necessity for this, other than the simplicity of implementing `Drop` given the `hid_free_enumeration` function. If we break from this function and write our own `Drop` that `free`s all of the fields manually, each `Device` is wholly independent, and can be owned anywhere in memory. In my use case, I need to pass a `Device` between threads, and this is not possible given that the `Devices` share the same lifetime.

Also, the `hidapi` maintainers [have stated that the linux and Mac versions are completely thread safe](https://github.com/signal11/hidapi/issues/56), so it should be safe to mark `Device` as `Send` on those platforms.