### PR TITLE
handle: use an initialized Vec in read_from

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -133,7 +133,7 @@ impl<'a> Data<'a> {
 	/// Returns the report ID and the amount of read bytes or `None` if there was a timeout.
 	pub fn read_from<T: AsMut<[u8]>>(&mut self, mut data: T, timeout: Duration) -> error::Result<Option<(u8, usize)>> {
 		let     data   = data.as_mut();
-		let mut buffer = Vec::with_capacity(data.len() + 1);
+		let mut buffer = vec![0; data.len() + 1];
 
 		if let Some(length) = self.read(&mut buffer, timeout)? {
 			data[0..length - 1].copy_from_slice(&buffer[1..length]);


### PR DESCRIPTION
By using `Vec::with_capacity` we reserve the space but its actual length is 0,
thus we pass along an empty slice to the read function which is always going to
fail because there's nowhere to write data to.

Use the `vec!` macro to initialize the vector to the correct size while zeroing
out the contents so we have somewhere for the read function to write the data
into.